### PR TITLE
Add scripts-docker option to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Each of the `*-docker` commands runs a full build in the given style:
  * `app-docker` for testing OMERO.web applications
  * `cli-docker` for testing `omero-cli-*` projects
  * `lib-docker` for testing client-side libraries
+ * `scripts-docker` for testing OMERO.scripts in the ```DIR_SCRIPTS``` location
 
 These scripts are invoked directly by the `script` step in project .travis.yml
 files.


### PR DESCRIPTION
Not sure if the ```DIR_SCRIPTS``` variable is now required?
If it's not there, do you still do ```rm -rf $OMERO_DIST/lib/scripts/omero``` in ```scripts-copy```?

It would be nice to have even more info in the README, so that omero-test-infra is usable without having to read all the source.